### PR TITLE
Upgrade dependency versions in `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,18 +42,18 @@
         </sonar.jacoco.reportPath>
 
         <!-- Dependencies versions -->
-        <farao-dichotomy.version>4.28.0</farao-dichotomy.version>
-        <gridcapa-cse.version>1.45.0</gridcapa-cse.version>
-        <gridcapa-swe.version>1.37.0</gridcapa-swe.version>
+        <farao-dichotomy.version>4.32.0</farao-dichotomy.version>
+        <gridcapa-cse.version>1.46.0</gridcapa-cse.version>
+        <gridcapa-swe.version>1.40.0</gridcapa-swe.version>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
-        <logback.version>1.5.6</logback.version>
+        <logback.version>1.5.18</logback.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven.checkstyle.version>3.3.1</maven.checkstyle.version>
         <maven.jacoco.version>0.8.10</maven.jacoco.version>
-        <powsybl.entsoe.version>2.13.0</powsybl.entsoe.version>
-        <powsybl.openloadflow.version>1.15.0</powsybl.openloadflow.version>
-        <powsybl.rao.version>6.5.0</powsybl.rao.version>
-        <powsybl.version>6.7.0</powsybl.version>
+        <powsybl.entsoe.version>2.14.0</powsybl.entsoe.version>
+        <powsybl.openloadflow.version>1.16.0</powsybl.openloadflow.version>
+        <powsybl.rao.version>6.6.0</powsybl.rao.version>
+        <powsybl.version>6.8.0</powsybl.version>
         <slf4j.version>2.0.13</slf4j.version>
     </properties>
 


### PR DESCRIPTION
# Summary
This PR updates several dependency versions in the pom.xml file to newer releases.

# Main changes:
Updated dependencies:
- farao-dichotomy to version 4.32.0
- gridcapa-cse to version 1.46.0
- gridcapa-swe to version 1.40.0
- logback to version 1.5.18
- powsybl.entsoe to version 2.14.0
- powsybl.openloadflow to version 1.16.0
- powsybl.rao to version 6.6.0
- powsybl to version 6.8.0

This change keeps the project dependencies up to date with their latest versions.